### PR TITLE
Add a ManifestAnnotator

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,6 +14,7 @@ pipeline {
             steps {
                 step([$class: 'AlvariumBuilder', annotationType: 'GIT'])
                 sh 'mvn package'
+                step([$class: 'AlvariumBuilder', annotationType: 'MANIFEST'])
             }
         }
     }

--- a/src/main/java/com/alvarium/annotators/AnnotatorFactory.java
+++ b/src/main/java/com/alvarium/annotators/AnnotatorFactory.java
@@ -39,6 +39,8 @@ public class AnnotatorFactory {
         return new GitAnnotator(hash, signature);
       case ARTIFACT:
         return new ArtifactAnnotator(hash, signature);
+      case MANIFEST:
+        return new ManifestAnnotator(hash, signature);
       case SOURCE:
         return new SourceAnnotator(hash, signature);
       default:

--- a/src/main/java/com/alvarium/annotators/ManifestAnnotator.java
+++ b/src/main/java/com/alvarium/annotators/ManifestAnnotator.java
@@ -1,0 +1,65 @@
+package com.alvarium.annotators;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.time.Instant;
+
+import com.alvarium.contracts.Annotation;
+import com.alvarium.contracts.AnnotationType;
+import com.alvarium.contracts.PipelineAnnotation;
+import com.alvarium.hash.HashType;
+import com.alvarium.sign.SignatureInfo;
+import com.alvarium.utils.PropertyBag;
+
+class ManifestAnnotator extends AbstractAnnotator implements Annotator {
+    
+    private final HashType hash;
+    private final AnnotationType kind;
+    private final SignatureInfo signature;
+
+    protected ManifestAnnotator(HashType hash, SignatureInfo signature) {
+        this.hash = hash;
+        this.kind = AnnotationType.MANIFEST;
+        this.signature = signature;
+    }
+
+    // takes the manifest file e.g., package.json, go.mod, etc. as 
+    // a byte array input
+    //
+    // expects pipelineId from ctx
+    @Override
+    public Annotation execute(PropertyBag ctx, byte[] data) throws AnnotatorException {
+        final String key = super.deriveHash(hash, data);
+        
+        String host;
+
+        try {
+            host = InetAddress.getLocalHost().getHostName();
+        } catch (UnknownHostException e) {
+            throw new AnnotatorException("Cannot get host name", e);
+        }
+
+        final Boolean isSatisfied = true;
+
+        final String pipelineId = ctx.getProperty("pipelineId", String.class);
+
+        final Annotation annotation = new PipelineAnnotation(
+            key, 
+            hash, 
+            host, 
+            kind, 
+            null, 
+            isSatisfied, 
+            Instant.now(), 
+            pipelineId
+        );
+
+        final String annotationSignature = super.signAnnotation(
+            signature.getPrivateKey(),
+            annotation
+        );
+
+        annotation.setSignature(annotationSignature);
+        return annotation;
+    }
+}

--- a/src/main/java/com/alvarium/contracts/AnnotationType.java
+++ b/src/main/java/com/alvarium/contracts/AnnotationType.java
@@ -31,6 +31,8 @@ public enum AnnotationType {
   GIT,
   @SerializedName(value = "artifact")
   ARTIFACT,
+  @SerializedName(value = "manifest")
+  MANIFEST,
   @SerializedName(value = "src")
   SOURCE;
 }


### PR DESCRIPTION
* Add an implementation for the ManifestAnnotator that takes the package manifest file of a project e.g., package.json or go.mod as a byte array input
* Added releveant definitions for the new annotator type